### PR TITLE
Add Streamlit chat UI and OpenAI agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment configuration for ChataLyst AI
+OPENAI_API_KEY=

--- a/app/core/agents/__init__.py
+++ b/app/core/agents/__init__.py
@@ -1,9 +1,11 @@
 """Agents 套件初始化"""
 from .base import BaseAgent, BaseDeps, AgentOutput
+from .openai_chat import OpenAIChatAgent
 
 __all__ = [
     "BaseAgent",
     "BaseDeps",
     "AgentOutput",
+    "OpenAIChatAgent",
 ]
 

--- a/app/core/agents/openai_chat.py
+++ b/app/core/agents/openai_chat.py
@@ -1,0 +1,17 @@
+import openai
+from typing import List, Dict
+from app.config import OPENAI_API_KEY, AI_MODEL
+
+
+class OpenAIChatAgent:
+    """Simple chat agent using OpenAI ChatCompletion."""
+
+    def __init__(self, model: str | None = None) -> None:
+        self.api_key = OPENAI_API_KEY
+        self.model = model or AI_MODEL or "gpt-3.5-turbo"
+        openai.api_key = self.api_key
+
+    def chat(self, messages: List[Dict[str, str]]) -> str:
+        """Send chat messages to the OpenAI API and return the reply."""
+        resp = openai.ChatCompletion.create(model=self.model, messages=messages)
+        return resp["choices"][0]["message"]["content"].strip()

--- a/app/ui/app.py
+++ b/app/ui/app.py
@@ -1,0 +1,22 @@
+import streamlit as st
+from app.core.agents import OpenAIChatAgent
+
+st.set_page_config(page_title="ChataLyst AI Chat", page_icon="🤖")
+
+st.title("ChataLyst AI Chat")
+
+if "conversation" not in st.session_state:
+    st.session_state.conversation = []
+
+agent = OpenAIChatAgent()
+
+for msg in st.session_state.conversation:
+    st.chat_message(msg["role"]).write(msg["content"])
+
+if prompt := st.chat_input("請輸入訊息..."):
+    st.session_state.conversation.append({"role": "user", "content": prompt})
+    with st.spinner("Thinking..."):
+        reply = agent.chat(st.session_state.conversation)
+    st.session_state.conversation.append({"role": "assistant", "content": reply})
+    st.chat_message("user").write(prompt)
+    st.chat_message("assistant").write(reply)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,6 @@ sqlalchemy>=2.0.23
 # 資料庫依賴
 aiosqlite>=0.19.0
 psycopg>=3.1.12
-psycopg-pool>=3.1.8 
+psycopg-pool>=3.1.8
+openai>=1.3.0
+streamlit>=1.32.0

--- a/tests/core/test_openai_chat_agent.py
+++ b/tests/core/test_openai_chat_agent.py
@@ -1,0 +1,25 @@
+import importlib
+import os
+
+import openai
+
+
+def test_openai_chat_agent_uses_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    import app.config
+    importlib.reload(app.config)
+    import app.core.agents.openai_chat as chat_mod
+    importlib.reload(chat_mod)
+
+    called = {}
+
+    def fake_create(**kwargs):
+        called["api_key"] = openai.api_key
+        return {"choices": [{"message": {"content": "hi"}}]}
+
+    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+    agent = chat_mod.OpenAIChatAgent()
+    assert agent.api_key == "test-key"
+    reply = agent.chat([{"role": "user", "content": "hi"}])
+    assert reply == "hi"
+    assert called["api_key"] == "test-key"


### PR DESCRIPTION
## Summary
- add simple OpenAI chat agent
- expose `OpenAIChatAgent` in agents package
- add Streamlit UI for chatting
- document environment variable for OpenAI
- include OpenAI and Streamlit dependencies
- add unit test for chat agent

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*